### PR TITLE
feat: add stdin support into the Run methods

### DIFF
--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -5,7 +5,9 @@
 package cmd_test
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -109,6 +111,10 @@ func (suite *CmdSuite) TestRun() {
 			suite.Assert().NoError(err)
 		}
 	}
+
+	stdout, err := cmd.RunContext(cmd.WithStdin(context.Background(), strings.NewReader("hello")), "xargs", "echo")
+	suite.Assert().NoError(err)
+	suite.Assert().Equal(stdout, "hello\n")
 }
 
 func TestCmdSuite(t *testing.T) {


### PR DESCRIPTION
Luks encryption is passing encryption keys using stdin.
Used the context to minimize the impact of the changes and keep the interface backwards compatible.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>